### PR TITLE
Derive std::exception and throw it on false result

### DIFF
--- a/KinectServer/KinectDevice.cpp
+++ b/KinectServer/KinectDevice.cpp
@@ -1,4 +1,7 @@
 #include "KinectDevice.h"
+#include <iostream>
+
+struct KinectInitializationFailure : std::exception {};
 
 KinectDevice::KinectDevice():
     sensor(NULL),
@@ -8,8 +11,8 @@ KinectDevice::KinectDevice():
 {
     auto validate = [this](int32_t result) {
         this->isValid = result;
-        if (FAILED(this->isValid)) {
-            throw "Initializing Kinect device failed.";
+        if (this->isValid == 0) {
+            throw KinectInitializationFailure();
         }
     };
 

--- a/KinectServer/KinectDevice.cpp
+++ b/KinectServer/KinectDevice.cpp
@@ -11,7 +11,7 @@ KinectDevice::KinectDevice():
 {
     auto validate = [this](int32_t result) {
         this->isValid = result;
-        if (this->isValid == 0) {
+        if (this->isValid <= 0) {
             throw KinectInitializationFailure();
         }
     };


### PR DESCRIPTION
This fixes the error not throwing by explicitly checking that the result
is zero. According to the doc, `SUCCESS` is true only if the result is
non-negative. The inverse is true for `FAIL`, but in our case, zero is not
non-negative. We here explicitly check for 0.

Also, throwing with a string is not available nor is it recommended in the
event that the copy constructor for the std::string also throws its own
exception.

/cc @cantsin 
