### PR TITLE
Add a wait time to the while loop

### DIFF
--- a/KinectServer/KinectServer.cpp
+++ b/KinectServer/KinectServer.cpp
@@ -5,6 +5,8 @@ using websocketpp::lib::bind;
 using websocketpp::lib::placeholders::_1;
 using websocketpp::lib::placeholders::_2;
 
+#define WAIT_TIME 8u
+
 KinectServer::KinectServer()
 {
     device = new KinectDevice();
@@ -72,6 +74,7 @@ void KinectServer::process_data() {
         auto bodies = device->capture();
 
         if (bodies.empty() || connections.empty()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(WAIT_TIME));
             continue;
         }
 


### PR DESCRIPTION
This is a minor change that doesn't seem to affect the display of
kinect skeletons. The benefit I see is that it reduces CPU usage
from 25% of a quad core to ~1%.

The number can be 9 (above that, the skeletons are paused
because the server probably waits too long), but I set it to 8.

I'm not sure if this is a good approach.
